### PR TITLE
Add homee node

### DIFF
--- a/nodes/virtualHomee.js
+++ b/nodes/virtualHomee.js
@@ -1,5 +1,6 @@
 const enums = require('homee-api/lib/enums');
 const VirtualHomee = require('../lib/virtualHomee');
+const Device = require('../lib/device');
 const discovery = require('../lib/discovery');
 const icons = require('../lib/icons');
 
@@ -41,6 +42,9 @@ module.exports = function (RED) {
       this.devices = [];
       this.attributeMap = {};
       this.childNodes = {};
+
+      const homeeNode = new Device('homee', -1, 1, [], 'default');
+      this.devices.push(homeeNode);
 
       node.debug('discovering devices');
       RED.nodes.eachNode((n) => {

--- a/nodes/virtualHomee.js
+++ b/nodes/virtualHomee.js
@@ -65,7 +65,7 @@ module.exports = function (RED) {
         node.error('The device IDs and the attribute IDs must be unique');
       }
 
-      node.debug(`found ${this.devices.length} devices`);
+      node.debug(`found ${this.devices.length - 1} devices`);
 
       this.api.setNodes(this.devices);
 


### PR DESCRIPTION
homee expects a homee node when using homee in homee, so you have to create two devices, even when you only need one.

Adding a homee node allows you to use only one virtual device.