### PR TITLE
fix disconnect issue with homee 2.33

### DIFF
--- a/lib/virtualHomee.js
+++ b/lib/virtualHomee.js
@@ -230,6 +230,7 @@ class VirtualHomee extends EventEmitter {
           + '        "data": {}\n'
           + '    }\n'
           + '}');
+        ws.close(4444, 'DEVICE_DISCONNECT');
       }
     }
   }


### PR DESCRIPTION
homee 2.33 (beta1) was not able to connect to node-red-contrib-homee.
Problem was a missing "active" disconnect from virtual homee to homee after sending warning message.